### PR TITLE
Only run for new PRs or commits

### DIFF
--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -9,6 +9,7 @@ case $ACTION in
 	synchronize)
 		;;
 	*)
+		echo "Not a PR open or push, exiting"
 		exit 0
 		;;
 esac

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 set -e
 
-cat /github/workflow/event.json
+# See what kind of action this is
+ACTION=$(cat /github/workflow/event.json | jq -r .action)
+case $ACTION in
+	opened)
+		exit 0
+		;;
+	synchronize)
+		exit 0
+		;;
+esac
 
 cd "${GO_WORKING_DIR:-.}"
 

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -5,9 +5,10 @@ set -e
 ACTION=$(cat /github/workflow/event.json | jq -r .action)
 case $ACTION in
 	opened)
-		exit 0
 		;;
 	synchronize)
+		;;
+	*)
 		exit 0
 		;;
 esac

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+cat /github/workflow/event.json
+
 cd "${GO_WORKING_DIR:-.}"
 
 # Check if any files are not formatted.


### PR DESCRIPTION
Last time we tried this, it ran for every review request as well. We obviously don't need that. Check the actual action for "opened" or "synchronize" and terminate early if it's anything else.

For reference, [here's the payload json from pushing to an open PR](https://gist.github.com/ajanata/a961885c7ba0ae3a3e6c6d99ba8ab714).